### PR TITLE
fixes #26: Allowed admin to edit user profile without entering first name and last name

### DIFF
--- a/server/php/Slim/public/admin-config.php
+++ b/server/php/Slim/public/admin-config.php
@@ -354,17 +354,11 @@ $tables = array(
                     'name' => 'first_name',
                     'label' => 'First Name',
                     'type' => 'string',
-                    'validation' => array(
-                        'required' => true,
-                    ) ,
                 ) ,
                 2 => array(
                     'name' => 'last_name',
                     'label' => 'Last Name',
                     'type' => 'string',
-                    'validation' => array(
-                        'required' => true,
-                    ) ,
                 ) ,
                 3 => array(
                     'name' => 'is_active',


### PR DESCRIPTION
Admin can't activate user account without filling first name and last name. So required validation removed for first name and last name. 